### PR TITLE
Fix EXISTS to return integer type

### DIFF
--- a/fakenewsredis.py
+++ b/fakenewsredis.py
@@ -340,8 +340,10 @@ class FakeStrictRedis(object):
         return value
 
     def exists(self, name):
+        return int(name in self._db)
+
+    def __contains__(self, name):
         return name in self._db
-    __contains__ = exists
 
     def expire(self, name, time):
         return self._expire(name, time)

--- a/test_fakenewsredis.py
+++ b/test_fakenewsredis.py
@@ -3074,6 +3074,17 @@ class TestFakeStrictRedis(unittest.TestCase):
         val = self.redis.get('foo')
         self.assertEqual(val, b'baz')
 
+    def test_eval_exists(self):
+        lua = 'return redis.call("EXISTS", KEYS[1])'
+        val = self.redis.eval(lua, 1, 'foo')
+        self.assertEqual(val, 0)
+        self.assertIsInstance(val, int)
+
+        self.redis.set('foo', 'foo')
+        val = self.redis.eval(lua, 1, 'foo')
+        self.assertEqual(val, 1)
+        self.assertIsInstance(val, int)
+
     def test_eval_lrange(self):
         self.redis.lpush("foo", "bar")
         val = self.redis.eval('return redis.call("LRANGE", KEYS[1], 0, 1)', 1, 'foo')


### PR DESCRIPTION
django-redis uses the following EVAL script for `incr`:

    local exists = redis.call('EXISTS', KEYS[1])
    if (exists == 1) then
        return redis.call('INCRBY', KEYS[1], ARGV[1])
    else return false end

NOTE the "if (exists == 1)" there and that "true" is not equal to 1 in
Lua.

Ref: https://redis.io/commands/exists