### PR TITLE
Add option to create an instance with non-shared data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ test you run, be sure to call `r.flushall()` in your
         # Clear data in fakenewsredis.
         self.r.flushall()
 
+Alternatively, you can create an instance that does not share data with other
+instances, by passing `singleton=False` to the constructor.
 
 Fakenewsredis implements the same interface as `redis-py`_, the
 popular redis client for python, and models the responses

--- a/test_fakenewsredis.py
+++ b/test_fakenewsredis.py
@@ -3644,6 +3644,24 @@ class TestInitArgs(unittest.TestCase):
         fakenewsredis.FakeRedis(foo='bar', bar='baz')
         fakenewsredis.FakeStrictRedis(foo='bar', bar='baz')
 
+    def test_singleton(self):
+        r1 = fakenewsredis.FakeStrictRedis(singleton=False)
+        r2 = fakenewsredis.FakeStrictRedis(singleton=False)
+        r3 = fakenewsredis.FakeStrictRedis()
+        r4 = fakenewsredis.FakeStrictRedis()
+        r3.flushall()
+
+        r1.set('foo', 'bar')
+        r3.set('bar', 'baz')
+
+        self.assertIn('foo', r1)
+        self.assertNotIn('foo', r2)
+        self.assertNotIn('foo', r3)
+
+        self.assertIn('bar', r3)
+        self.assertIn('bar', r4)
+        self.assertNotIn('bar', r1)
+
     def test_from_url(self):
         db = fakenewsredis.FakeStrictRedis.from_url(
             'redis://username:password@localhost:6379/0')


### PR DESCRIPTION
If `single=False` is given to the FakeStrictRedis constructor, it
creates its own set of databases instead of using the global one.